### PR TITLE
docs: finalize README/QUICK_START; fix roadmap link; align status with deployed services

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ flowchart LR
 # Install required tools
 aws --version          # AWS CLI v2
 terraform --version    # Terraform 1.5+
-{{ADDITIONAL_PREREQUISITES}}
+python --version       # Python 3.8+
+git --version          # Git CLI
 
 # Configure AWS credentials
 aws configure sso --profile aws-ml-integration-demo
@@ -187,7 +188,7 @@ aws-ml-integration-demo/
 │   └── Lambda/ # Secondary service implementation
 ├── terraform/             # 🏗️ Infrastructure as Code
 │   ├── main.tf           # Core infrastructure configuration
-│   ├── {{SERVICE_1}}.tf  # Service-specific configurations
+│   ├── modules/          # Service-specific configurations (optional modules)
 │   ├── variables.tf      # Input variables
 │   └── outputs.tf        # Output values
 ├── testing/               # 🧪 Testing & validation


### PR DESCRIPTION
Summary

README: aligned Basic vs Enterprise scope, added SageMaker demo section, fixed Enterprise Roadmap link, removed placeholders, added architecture mermaid, concrete run/test steps.
QUICK_START: replaced placeholders with real verification, Bedrock/API notes, correct cleanup verification via Terraform.
PROJECT_STATUS: updated to reflect deployed services and added roadmap.
Validation

Terraform unchanged for this PR.
Links verified locally: [PROJECT_STATUS.md](vscode-file://vscode-app/c:/Users/jpand/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and outputs-driven console links.
Reviewer checklist

 README has no remaining placeholders
 QUICK_START steps are clear and copy/pasteable for PowerShell
 PROJECT_STATUS reflects current state and roadmap
 Optional: confirm Terraform outputs show sagemaker_notebook and dashboard_urls
Note

One template-style token remains in [aws_ml_integration.py](vscode-file://vscode-app/c:/Users/jpand/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as an example payload; say the word and I’ll clean or keep it as-is.